### PR TITLE
refactor(transloco): wrap transloco pipe in parentheses for consistency

### DIFF
--- a/src/app/components/client-beneficiary-form/client-beneficiary-form.component.html
+++ b/src/app/components/client-beneficiary-form/client-beneficiary-form.component.html
@@ -195,7 +195,7 @@
               <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
             </svg>
           </span>
-          {{ loading ? 'ENTITIES.BUTTONS.CREATING' : 'ENTITIES.BUTTONS.CREATE' | transloco}}
+          {{ loading ? ('ENTITIES.BUTTONS.CREATING'| transloco) : ('ENTITIES.BUTTONS.CREATE' | transloco)}}
         </button>
       </div>
 

--- a/src/app/components/transaction-form/transaction-form.component.html
+++ b/src/app/components/transaction-form/transaction-form.component.html
@@ -177,7 +177,7 @@
                 <svg class="w-5 h-5 mr-2 me-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path>
                 </svg>
-                {{ loading ? 'PDF.BUTTONS.PROCESSING' : 'PDF.BUTTONS.GENERATE' | transloco}}
+                {{ loading ? ('PDF.BUTTONS.PROCESSING' | transloco) : ('PDF.BUTTONS.GENERATE' | transloco)}}
               </button>
             </div>
 


### PR DESCRIPTION
Wrap the transloco pipe in parentheses in button labels to ensure consistency and improve readability. This change applies to both the client-beneficiary-form and transaction-form components.